### PR TITLE
Resume formatting options

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ fn router() -> Router {
         .route("/home", get(content_home))
         .route("/about", get(about_page))
         .route("/resume", get(resume_page))
+        .route("/alt", get(alt_page))
         .fallback(Redirect::permanent("/"))
 }
 
@@ -107,5 +108,26 @@ async fn resume_page() -> Html<String> {
     crate::mdext::enable_extensions(&mut options);
     let html = markdown_to_html(md, &options);
     let template = ContentTemplate { content: html };
+    Html(template.render().unwrap())
+}
+
+
+/// Loads google doc version in an iframe
+/// use in route:
+/// ```rust
+/// Route::new().route("/alt", get(alt_page))
+/// ```
+async fn alt_page() -> Html<String> {
+    let mut options = ComrakOptions::default();
+    crate::mdext::enable_extensions(&mut options);
+    let raw_html = r#"
+        <iframe
+            width="100%"
+            height="100%"
+            style="border: none;"
+            title="Jeremy's Resume Google Doc"
+            src="https://docs.google.com/document/d/e/2PACX-1vStq85F8GrnQKq990ujlCCwWkwYCx7PzGc6bu4MlLEOZ3y-hV_fM8hM6W52jvS5-HBLPLJUGtqOqxwz/pub" 
+        ></iframe>"#;
+    let template = IndexTemplate { content: raw_html.to_string(), content_box: false };
     Html(template.render().unwrap())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,14 +25,12 @@ fn router() -> Router {
         .fallback(Redirect::permanent("/"))
 }
 
-
-// Main entry point for Cloudflare Worker
+/// Main entry point for Cloudflare Worker
 #[event(fetch)]
 async fn fetch(req: HttpRequest, _env: Env, _ctx: Context) -> Result<axum::http::Response<axum::body::Body>> {
     console_error_panic_hook::set_once();
     Ok(router().call(req).await?)
 }
-
 
 /// Extends layout.html (navbar, buttons and footer)
 #[derive(Template)]
@@ -40,6 +38,7 @@ async fn fetch(req: HttpRequest, _env: Env, _ctx: Context) -> Result<axum::http:
 struct IndexTemplate {
     content: String,
     content_box: bool,
+    button_box: bool,
 } 
 
 /// Does not extend layout.html
@@ -59,10 +58,9 @@ async fn home_page() -> Html<String> {
     let mut options = ComrakOptions::default();
     crate::mdext::enable_extensions(&mut options); 
     let html = markdown_to_html(&HOME_MD, &options);
-    let template = IndexTemplate { content: html, content_box: true }; 
+    let template = IndexTemplate { content: html, content_box: true, button_box: true }; 
     Html(template.render().unwrap())
 }
-
 
 /// Loads home.md, content_template.html.
 /// use in router:
@@ -76,7 +74,6 @@ async fn content_home() -> Html<String> {
     let template = ContentTemplate { content: html };
     Html(template.render().unwrap())
 }
-
 
 /// Loads about.md with ContentTemplate
 /// use in router:
@@ -95,8 +92,6 @@ async fn about_page() -> Html<String> {
     Html(template.render().unwrap())
 }
 
-
-
 /// Loads about.md with ContentTemplate
 /// use in router:
 /// ```rust
@@ -111,7 +106,6 @@ async fn resume_page() -> Html<String> {
     Html(template.render().unwrap())
 }
 
-
 /// Loads google doc version in an iframe
 /// use in route:
 /// ```rust
@@ -121,13 +115,19 @@ async fn alt_page() -> Html<String> {
     let mut options = ComrakOptions::default();
     crate::mdext::enable_extensions(&mut options);
     let raw_html = r#"
+    </div>
+    <div class=container is-center>
+        <a class="button is-large" href="/">Home</a>
+        <a class="button is-large" href="https://cdn.j51b5.com/content/pfd-may-2025-JG-Resume.pdf">Download as PDF</a>
         <iframe
+            src="https://docs.google.com/document/d/e/2PACX-1vStq85F8GrnQKq990ujlCCwWkwYCx7PzGc6bu4MlLEOZ3y-hV_fM8hM6W52jvS5-HBLPLJUGtqOqxwz/pub?embedded=true"
             width="100%"
-            height="100%"
-            style="border: none;"
-            title="Jeremy's Resume Google Doc"
-            src="https://docs.google.com/document/d/e/2PACX-1vStq85F8GrnQKq990ujlCCwWkwYCx7PzGc6bu4MlLEOZ3y-hV_fM8hM6W52jvS5-HBLPLJUGtqOqxwz/pub" 
-        ></iframe>"#;
-    let template = IndexTemplate { content: raw_html.to_string(), content_box: false };
+            height="1000"
+            marginheight="0"
+            marginwidth="0"
+        ></iframe>
+    </div>
+    "#;
+    let template = IndexTemplate { content: raw_html.to_string(), content_box: false, button_box: false };
     Html(template.render().unwrap())
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -33,7 +33,7 @@
   </div>
 </div>
 {% endif %}
-
+{% if button_box %}
 <body>
     <div class="block has-text-centered" style="margin: 2vh auto 0 auto;">
       <!-- dont push url.. going to /home loads raw markdown this is intended for later use in markdown reader -->
@@ -42,6 +42,7 @@
       <button class="button is-large" hx-get="/resume" hx-target="#content" hx-swap="innerHTML" hx-push-url="false">Resume</button>
 
     </div>
+{% endif %}
     <div class="block is-flex is-flex-direction-column is-align-items-center" 
          style="margin: 2vh auto 0 auto;" id="content"> 
       <div class="block">

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,6 +1,5 @@
 <!doctype html>
 <html lang="en">
-
   <head>
     <meta charset="utf-8">
     <!-- Primary Meta Tags -->
@@ -107,7 +106,6 @@
     <div class="site-wrapper">
       <!-- start of navbar -->
       <nav class="navbar has-shadow is-dark is-flex is-justify-content-space-between" role="navigation" aria-label="main navigation">
-
         <!-- Navbar menu -->
         <div class="navbar-brand">
           <div class="navbar-start">

--- a/templates/md/home.md
+++ b/templates/md/home.md
@@ -7,4 +7,4 @@
 
 ---
 
-[![Static Badge](https://img.shields.io/badge/Hire_me!-Currently_Seeking_Employment-red?style=flat)](https://docs.google.com/document/d/e/2PACX-1vStq85F8GrnQKq990ujlCCwWkwYCx7PzGc6bu4MlLEOZ3y-hV_fM8hM6W52jvS5-HBLPLJUGtqOqxwz/pub)
+[![Static Badge](https://img.shields.io/badge/Hire_me!-Currently_Seeking_Employment-red?style=flat)](/alt)

--- a/templates/md/resume.md
+++ b/templates/md/resume.md
@@ -1,4 +1,6 @@
-# Jeremy Grosenstein  
+[View as PDF](/alt)
+
+# **Jeremy Grosenstein**  
 **201-655-2621** | [jeremy51b5@pm.me](mailto:jeremy51b5@pm.me) | [j51b5.com](https://j51b5.com) | [GitHub](https://github.com/Jeremy-Gstein)
 
 ---
@@ -27,16 +29,19 @@ Highly motivated team player passionate about Linux, Security, and Open Source s
 ---
 
 ## **CERTIFICATIONS**
+
 - **Red Hat Certified SysAdmin v9** (July 2023)
 
 ---
 
 ## **LEADERSHIP**
 ### National Cyber League
+
 - Top 500 (2021), 89th percentile (2022)  
 - Skills: Packet analysis, OSINT investigations, Script reverse engineering
 
 ### Cyber Security Club Leadership
+
 - Led virtual transition using Slack/Discord  
 - Managed funding requests for competitions
 
@@ -44,12 +49,14 @@ Highly motivated team player passionate about Linux, Security, and Open Source s
 
 ## **ACADEMIC PROJECTS**
 ### Linux From Scratch
-Built custom distro demonstrating core components  
-[Demo Video](https://youtu.be/2GQZs2Js6pg)
+
+- Built custom distro demonstrating core components  
+  * [Demo Video](https://youtu.be/2GQZs2Js6pg)
 
 ### MITM Attack Demo
-Showcased ARP spoofing risks  
-[Presentation](https://youtu.be/D19emjjg1x0)
+
+- Showcased ARP spoofing risks  
+  * [Presentation](https://youtu.be/D19emjjg1x0)
 
 ---
 
@@ -65,5 +72,3 @@ Showcased ARP spoofing risks
 ---
 
 *References available upon request*
-
-[view as pdf](/alt)

--- a/templates/md/resume.md
+++ b/templates/md/resume.md
@@ -66,4 +66,4 @@ Showcased ARP spoofing risks
 
 *References available upon request*
 
-last update: ${CURRENT_MONTH}-${CURRENT_YEAR}
+[view as pdf](/alt)


### PR DESCRIPTION
Testing iframe as way of getting dynamic content. currently getting resume from google docs published URL. This lets users see most up-to-date resume whenever a change is made.

Minor formatting changes to empty lines in various files.

TODO: not rely on google and instead embed the doc in r2 storage. 
- A method for managing resume on r2 
- Sync, Update, Cache old-resume with deletion policy
Current idea is use this github repository, if change to resume.md -> r2-storage-update